### PR TITLE
GH2: Correcting issue with MaxParallelism setting.

### DIFF
--- a/src/Cake.Chutzpah/ChutzpahRunner.cs
+++ b/src/Cake.Chutzpah/ChutzpahRunner.cs
@@ -134,7 +134,7 @@ namespace Cake.Chutzpah
 
             if (settings.MaxParallelism.HasValue)
             {
-                argBuilder.Append("/parallelism {0}", settings.MaxParallelism);
+                argBuilder.Append("/parallelism").Append(settings.MaxParallelism.ToString());
             }
 
             if (!settings.OutputRunningTestCount)


### PR DESCRIPTION
The property is a nullable int and it isn't being correctly set.  We
have been running a patched version for over a year, but would like to
start using the official version.